### PR TITLE
fix: prevent content scrolling visibility between title bar and header

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,11 +7,11 @@ import ConfigurationSelector from './components/ConfigurationSelector/Configurat
 function App() {
   return (
     <Layout>
-      <div style={{ position: 'sticky', top: '0', zIndex: 30, backgroundColor: 'var(--win95-light-gray)' }}>
+      <div style={{ backgroundColor: 'var(--win95-light-gray)' }}>
         <Header />
         <ActionBar />
       </div>
-      <div style={{ padding: '12px' }}>
+      <div style={{ padding: '12px', overflow: 'auto', flex: 1 }}>
         <SoftwareSelector />
         <ConfigurationSelector />
       </div>

--- a/src/components/Layout/Layout.jsx
+++ b/src/components/Layout/Layout.jsx
@@ -17,7 +17,7 @@ const Layout = ({ children }) => {
         </div>
 
         {/* Window Content */}
-        <div style={{ padding: '8px', maxHeight: 'calc(100vh - 100px)', overflow: 'auto' }}>
+        <div style={{ padding: '8px', display: 'flex', flexDirection: 'column', maxHeight: 'calc(100vh - 100px)' }}>
           {children}
         </div>
       </div>


### PR DESCRIPTION
Incredibly minor fix, I don't even use windows I use linux. But seeing through the scrolling list through the top of the header bothered me enough to get claude to fix it for me and help out a bit. Here is what it did:

## Summary
Fixed an issue where the scrolling content was visible between the Windows XP blue title bar and the header component, creating an unintended visual gap.

## Changes
- Restructured layout to move scroll behavior from outer container to only the content area
- Removed sticky positioning from header (no longer needed)
- Applied flexbox layout to properly contain scrolling to content area only

## Test plan
- [x] Verified header stays fixed at top
- [x] Verified content scrolls without showing in gap
- [x] Tested visual appearance matches Windows XP styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)