### PR TITLE
feat: add PhpStorm to development software

### DIFF
--- a/src/data/software-catalog.js
+++ b/src/data/software-catalog.js
@@ -54,6 +54,7 @@ import notepadPlusplus from './software/development/notepad-plusplus.js';
 import postman from './software/development/postman.js';
 import putty from './software/development/putty.js';
 import pycharmCommunity from './software/development/pycharm-community.js';
+import phpstorm from './software/development/phpstorm.js';
 import python from './software/development/python.js';
 import sublimeText from './software/development/sublime-text.js';
 import terminus from './software/development/terminus.js';
@@ -203,6 +204,7 @@ export const softwareCatalog = [
   postman,
   putty,
   pycharmCommunity,
+  phpstorm,
   python,
   sublimeText,
   terminus,

--- a/src/data/software/development/phpstorm.js
+++ b/src/data/software/development/phpstorm.js
@@ -1,0 +1,12 @@
+export default {
+  "id": "phpstorm",
+  "name": "PhpStorm",
+  "description": "Professional PHP IDE by JetBrains",
+  "category": "development",
+  "wingetId": "JetBrains.PHPStorm",
+  "icon": "SiPhpstorm",
+  "iconColor": "#B24EFF",
+  "popular": false,
+  "requiresAdmin": true,
+  "license": "paid"
+};


### PR DESCRIPTION
## Summary
Add JetBrains PhpStorm professional PHP IDE to the development category.

## Changes
- Add `src/data/software/development/phpstorm.js` with PhpStorm configuration
- Update `src/data/software-catalog.js` to include PhpStorm

## Software Details
- **Name**: PhpStorm
- **Winget ID**: `JetBrains.PHPStorm`
- **Category**: development
- **License**: paid

## Test plan
- [x] `npm test` passes
- [x] Schema validation passes